### PR TITLE
fix: resolve TypeError when accessing grade.exam.subject.schoolId

### DIFF
--- a/src/services/GradeService.ts
+++ b/src/services/GradeService.ts
@@ -19,7 +19,16 @@ export class GradeService {
   static async fetchAll(): Promise<Grade[]> {
     try {
       const { grade: gradeRepo } = getRepositories();
-      return await gradeRepo.find({ relations: ['exam'] });
+      return await gradeRepo.find({
+        relations: {
+          exam: {
+            subject: true,
+          },
+        },
+        order: {
+          date: 'DESC',
+        },
+      });
     } catch (error) {
       console.error('Failed to fetch grades:', error);
       throw error;


### PR DESCRIPTION
- Add null checks in calculateSchoolAverage function
- Update relations in GradeService to load subject data
- Change Grade-Exam relationship from OneToOne to ManyToOne
- Add eager loading for exam and subject relations