### PR TITLE
Fix: move orange priority dot to the right in exam cards

### DIFF
--- a/src/pages/home/HomePage.css
+++ b/src/pages/home/HomePage.css
@@ -358,6 +358,14 @@
 .exam-card-content {
   display: flex;
   align-items: center;
+  width: 95%;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.exam-icon-and-info {
+  display: flex;
+
   gap: 10px;
 }
 
@@ -398,6 +406,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  margin: 0;
 }
 
 .exam-date {
@@ -421,6 +430,7 @@
 .priority-dot {
   width: 6px;
   height: 6px;
+  right: 0;
   border-radius: 50%;
   background: #ff9500;
   box-shadow: 0 1px 4px rgba(255, 149, 0, 0.3);

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -215,16 +215,21 @@ function HomePage() {
                     }
                   >
                     <div className="exam-card-content">
-                      <div className="exam-icon-wrapper">
-                        <IonIcon icon={bookOutline} className="exam-icon" />
-                      </div>
+                      <div className="exam-icon-and-info">
+                        <div className="exam-icon-wrapper">
+                          <IonIcon icon={bookOutline} className="exam-icon" />
+                        </div>
 
-                      <div className="exam-info">
-                        <h4 className="exam-title">{exam.name}</h4>
-                        <div className="exam-meta">
-                          <div className="exam-date">
-                            <IonIcon icon={timeOutline} className="meta-icon" />
-                            <span>{formatDate(exam.date)}</span>
+                        <div className="exam-info">
+                          <h4 className="exam-title">{exam.name}</h4>
+                          <div className="exam-meta">
+                            <div className="exam-date">
+                              <IonIcon
+                                icon={timeOutline}
+                                className="meta-icon"
+                              />
+                              <span>{formatDate(exam.date)}</span>
+                            </div>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
- Wrapped icon and info in exam-icon-and-info` to separate from the dot