### PR TITLE
ci: add commit message lint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
## Summary
- add commitlint workflow to enforce conventional commit messages

## Testing
- `npm test`
- `npm run lint`

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_68a5d18f1d748332a3ab938cba1ad570