### PR TITLE
fix: continue button layout in onboarding name step

### DIFF
--- a/src/pages/onboarding/OnboardingPage.css
+++ b/src/pages/onboarding/OnboardingPage.css
@@ -189,7 +189,7 @@
 /* Footer Buttons */
 .step-footer {
   padding-top: 20px;
-  margin-top: auto;
+  padding-bottom: max(24px, calc(env(safe-area-inset-bottom) + 24px));
 }
 
 .button-group {

--- a/src/pages/onboarding/OnboardingPage.css
+++ b/src/pages/onboarding/OnboardingPage.css
@@ -189,7 +189,7 @@
 /* Footer Buttons */
 .step-footer {
   padding-top: 20px;
-  padding-bottom: max(24px, calc(env(safe-area-inset-bottom) + 24px));
+  margin-top: auto;
 }
 
 .button-group {


### PR DESCRIPTION
## Summary

Added `padding-bottom` with safe area insets support to `.step-footer` in `OnboardingPage.css`

## Testing

Tested locally using

- [ x ] `npm run dev`
- [ x ] `ionic capacitor run android`
- [ x ] `ionic capacitor run ios`

## Issue

- Closes [#157]
