### PR TITLE
fix: ios input focus validation bug

### DIFF
--- a/src/components/Form/FormField.tsx
+++ b/src/components/Form/FormField.tsx
@@ -99,7 +99,7 @@ const FormField: React.FC<FormFieldProps> = ({
           // For a text or number field, ensure we convert the value to string
           // to display in the input.
           value={value !== undefined && value !== null ? value.toString() : ''}
-          onIonChange={(e) => {
+          onIonInput={(e) => {
             // e.detail.value can be string | null | undefined
             handleGenericChange(e.detail.value);
           }}

--- a/src/components/Form/validated-number-input/validatedNumberInput.tsx
+++ b/src/components/Form/validated-number-input/validatedNumberInput.tsx
@@ -50,7 +50,7 @@ const ValidatedNumberInput: React.FC<ValidatedNumberInputProps> = ({
           <IonInput
             type="number"
             value={value}
-            onIonChange={handleInputChange}
+            onIonInput={handleInputChange}
             step={step}
             min={min}
             max={max}

--- a/src/pages/home/exams/EditExamPage/components/ExamDetailsForm.tsx
+++ b/src/pages/home/exams/EditExamPage/components/ExamDetailsForm.tsx
@@ -80,7 +80,7 @@ export const ExamDetailsForm: React.FC<ExamDetailsFormProps> = ({
           <IonItem className={styles.formItem}>
             <IonInput
               value={formValues.title}
-              onIonChange={(e) => handleTitleChange(e.detail.value || '')}
+              onIonInput={(e) => handleTitleChange(e.detail.value || '')}
               placeholder="Prüfungstitel"
               required
               className={styles.formInput}
@@ -104,7 +104,7 @@ export const ExamDetailsForm: React.FC<ExamDetailsFormProps> = ({
             <IonInput
               type="date"
               value={formValues.date}
-              onIonChange={(e) => handleDateChange(e.detail.value || '')}
+              onIonInput={(e) => handleDateChange(e.detail.value || '')}
               required
               className={styles.formInput}
             />

--- a/src/pages/onboarding/components/nameStep/NameStep.tsx
+++ b/src/pages/onboarding/components/nameStep/NameStep.tsx
@@ -50,7 +50,7 @@ const NameStep: React.FC<NameStepProps> = ({ data, setData, onNext }) => {
                 <IonInput
                   value={localName}
                   placeholder="Dein Vorname..."
-                  onIonChange={(e) => setLocalName(e.detail.value || '')}
+                  onIonInput={(e) => setLocalName(e.detail.value || '')}
                   className="input-field"
                   clearInput
                   autoFocus

--- a/src/pages/onboarding/components/subjectStep/SubjectStep.tsx
+++ b/src/pages/onboarding/components/subjectStep/SubjectStep.tsx
@@ -205,7 +205,7 @@ const SubjectStep: React.FC<SubjectStepProps> = ({
                         <IonInput
                           value={newSubject.name}
                           placeholder="z.B. Mathematik"
-                          onIonChange={(e) =>
+                          onIonInput={(e) =>
                             setNewSubject((prev) => ({
                               ...prev,
                               name: e.detail.value || '',
@@ -231,7 +231,7 @@ const SubjectStep: React.FC<SubjectStepProps> = ({
                         <IonInput
                           value={newSubject.teacher}
                           placeholder="z.B. Frau Schmidt"
-                          onIonChange={(e) =>
+                          onIonInput={(e) =>
                             setNewSubject((prev) => ({
                               ...prev,
                               teacher: e.detail.value || '',
@@ -257,7 +257,7 @@ const SubjectStep: React.FC<SubjectStepProps> = ({
                         <IonTextarea
                           value={newSubject.description}
                           placeholder="Zusätzliche Informationen..."
-                          onIonChange={(e) =>
+                          onIonInput={(e) =>
                             setNewSubject((prev) => ({
                               ...prev,
                               description: e.detail.value || '',


### PR DESCRIPTION
## Summary
Fixes iOS form validation bug where inputs with focus fail validation. Users had to manually dismiss keyboard before submitting forms. Changed `onIonChange` to `onIonInput` for all IonInput components to enable real-time state updates.

**Files changed:**
- `src/components/Form/FormField.tsx`
- `src/components/Form/validated-number-input/validatedNumberInput.tsx` 
- `src/pages/home/exams/EditExamPage/components/ExamDetailsForm.tsx`
- `src/pages/onboarding/components/nameStep/NameStep.tsx`
- `src/pages/onboarding/components/subjectStep/SubjectStep.tsx`

## Testing
Tested locally using
- [ ] `npm run dev`
- [ ] `ionic capacitor run android` 
- [ ] `ionic capacitor run ios`

**Manual tests:**
- [ ] AddGradePage: Enter grade → submit while input focused
- [ ] GradeEntryPage: Edit grade → save while input focused  
- [ ] Onboarding: Name input → continue while focused
- [ ] ExamForm: Title/date inputs → save while focused
- [ ] SubjectStep: Add subject → submit while focused

## Issue
- Closes #159 