### PR TITLE
feat(AddGradePage): auto-fill school and subject when adding a grade

### DIFF
--- a/src/pages/home/grades/AddGradePage.tsx
+++ b/src/pages/home/grades/AddGradePage.tsx
@@ -71,6 +71,7 @@ const AddGradePage: React.FC = () => {
       stateSubjectId &&
       stateSchoolId &&
       formData.selectedSchoolId === stateSchoolId &&
+      subjects?.length > 0 &&
       subjects.some((s) => s.id === stateSubjectId)
     ) {
       setFormData((prev) => ({ ...prev, selectedSubjectId: stateSubjectId }));

--- a/src/pages/home/grades/AddGradePage.tsx
+++ b/src/pages/home/grades/AddGradePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { IonContent, IonPage, IonToast } from '@ionic/react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, useLocation } from 'react-router-dom';
 import Button from '@/components/Button/Button';
 import Header from '@/components/Header/Header';
 import FormField from '@/components/Form/FormField';
@@ -30,6 +30,10 @@ interface GradeAddFormData {
 
 const AddGradePage: React.FC = () => {
   const history = useHistory();
+  const location = useLocation<{
+    schoolId?: string;
+    subjectId?: string;
+  }>();
   const { schoolId: routeSchoolId } = useParams<{ schoolId: string }>();
 
   const [formData, setFormData] = useState<GradeAddFormData>({
@@ -49,6 +53,29 @@ const AddGradePage: React.FC = () => {
   const { data: subjects = [], error: subjectsError } = useSchoolSubjects(
     formData.selectedSchoolId,
   );
+
+  useEffect(() => {
+    const state = location.state || {};
+    const stateSchoolId = state.schoolId || '';
+    const stateSubjectId = state.subjectId || '';
+
+    if (stateSchoolId && stateSchoolId !== formData.selectedSchoolId) {
+      setFormData((prev) => ({
+        ...prev,
+        selectedSchoolId: stateSchoolId,
+        selectedSubjectId: '',
+      }));
+    }
+
+    if (
+      stateSubjectId &&
+      stateSchoolId &&
+      formData.selectedSchoolId === stateSchoolId &&
+      subjects.some((s) => s.id === stateSubjectId)
+    ) {
+      setFormData((prev) => ({ ...prev, selectedSubjectId: stateSubjectId }));
+    }
+  }, [location.state, subjects, formData.selectedSchoolId]);
 
   // Show error messages if fetching fails
   useEffect(() => {

--- a/src/pages/home/grades/GradeEntryPage.tsx
+++ b/src/pages/home/grades/GradeEntryPage.tsx
@@ -46,7 +46,7 @@ interface GradeEntryParams {
 }
 
 const GradeEntryPage: React.FC = () => {
-  const { subjectId } = useParams<GradeEntryParams>();
+  const { schoolId, subjectId } = useParams<GradeEntryParams>();
   const history = useHistory();
 
   const {
@@ -169,7 +169,10 @@ const GradeEntryPage: React.FC = () => {
           <IonButtons slot="end">
             <Button
               handleEvent={() => {
-                history.push(Routes.GRADES_ADD);
+                history.push(Routes.GRADES_ADD, {
+                  schoolId,
+                  subjectId,
+                });
               }}
               text={<IonIcon icon={add} />}
             />


### PR DESCRIPTION
## Summary

Auto-fill School and Subject when opening the Add Grade form from a School/Subject context.
If opened globally (no context), fields remain empty as before.
User can still change the prefilled values

## Testing

Tested locally using

- [x] `npm run dev`
- [x] `ionic capacitor run android`
- [x] `ionic capacitor run ios`

## Issue

- Closes #150