### PR TITLE
feat: show subject.name as title in GradeEntryPage

### DIFF
--- a/src/hooks/queries/useGradeQueries.ts
+++ b/src/hooks/queries/useGradeQueries.ts
@@ -22,6 +22,14 @@ export const useGrades = () => {
     queryFn: () => GradeService.fetchAll(),
   });
 };
+
+export const useSubjectGrades = (subjectId: string) => {
+  return useQuery({
+    queryKey: gradeKeys.lists(),
+    queryFn: () => GradeService.findBySubjectId(subjectId),
+  });
+};
+
 export const useAddGradeWithExam = () => {
   const queryClient = useQueryClient();
 

--- a/src/services/GradeService.ts
+++ b/src/services/GradeService.ts
@@ -203,6 +203,33 @@ export class GradeService {
   }
 
   /**
+   *
+   *
+   * Finds grades by subject ID
+   * @param examId - The ID of the subject to find grades for
+   * @returns Promise<Grade[]> - A promise that resolves to an array of grades
+   */
+  static async findBySubjectId(subjectId: string): Promise<Grade[]> {
+    try {
+      const { grade: gradeRepo } = getRepositories();
+      return await gradeRepo.find({
+        where: {
+          exam: { subjectId },
+        },
+        relations: {
+          exam: { subject: true },
+        },
+      });
+    } catch (error) {
+      console.error(
+        `Failed to find grades for subject ID ${subjectId}:`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Updates both an exam and a grade in a single transaction
    * @param examData - The updated exam data
    * @param gradeData - The updated grade data

--- a/src/tests/services/GradeService.test.ts
+++ b/src/tests/services/GradeService.test.ts
@@ -99,6 +99,32 @@ describe('GradeService', () => {
     expect(grade?.exam).toBeDefined();
   });
 
+  // Test findBySubjectId method
+  it('should find grades by subject id', async () => {
+    const gradeData: AddExamAndGradePayload = {
+      subjectId: testData.subject.id,
+      examName: 'Subject ID Test Exam',
+      date: new Date(),
+      score: 88,
+      weight: 1.2,
+      comment: 'Subject-specific test',
+    };
+
+    const createdGrade = await GradeService.addWithExam(gradeData);
+
+    const foundGrades = await GradeService.findBySubjectId(testData.subject.id);
+
+    expect(Array.isArray(foundGrades)).toBe(true);
+    expect(foundGrades.length).toBeGreaterThan(0);
+
+    const match = foundGrades.find((g) => g.id === createdGrade.id);
+    expect(match).toBeDefined();
+    expect(match?.score).toBe(88);
+    expect(match?.weight).toBe(1.2);
+    expect(match?.exam).toBeDefined();
+    expect(match?.exam.subjectId).toBe(testData.subject.id);
+  });
+
   // Test findByExamId method
   it('should find grades by exam id', async () => {
     const grades = await GradeService.findByExamId(testData.exam.id);


### PR DESCRIPTION
## Summary

I’ve changed it so that when you click on a grade, the current subject you clicked on is shown above.

## Testing

Tested locally using

- [x] `npm run dev`
- [ ] `ionic capacitor run android`
- [ ] `ionic capacitor run ios`

## Issue

- Closes #146 
