### PR TITLE
fix: display success messages in green instead of red

### DIFF
--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -3,15 +3,21 @@ import { useState } from 'react';
 export const useToast = () => {
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
+  const [toastColor, setToastColor] = useState<'success' | 'danger'>('danger');
 
-  const showMessage = (message: string) => {
+  const showMessage = (
+    message: string,
+    color: 'success' | 'danger' = 'danger',
+  ) => {
     setToastMessage(message);
+    setToastColor(color);
     setShowToast(true);
   };
 
   return {
     showToast,
     toastMessage,
+    toastColor,
     setShowToast,
     showMessage,
   };

--- a/src/pages/home/grades/AddGradePage.tsx
+++ b/src/pages/home/grades/AddGradePage.tsx
@@ -50,6 +50,7 @@ const AddGradePage: React.FC = () => {
 
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
+  const [toastColor, setToastColor] = useState<'success' | 'danger'>('danger');
   const [showNavigationModal, setShowNavigationModal] = useState(false);
 
   const { data: schools = [], error: schoolsError } = useSchools();
@@ -167,8 +168,12 @@ const AddGradePage: React.FC = () => {
     }
   };
 
-  const showAndSetToastMessage = (message: string) => {
+  const showAndSetToastMessage = (
+    message: string,
+    color: 'success' | 'danger' = 'danger',
+  ) => {
     setToastMessage(message);
+    setToastColor(color);
     setShowToast(true);
   };
 
@@ -216,8 +221,8 @@ const AddGradePage: React.FC = () => {
           score: 0,
           comment: '',
         });
-        history.push(Routes.HOME);
-        showAndSetToastMessage('Note erfolgreich hinzugefügt.');
+        showAndSetToastMessage('Note erfolgreich hinzugefügt.', 'success');
+        setTimeout(() => history.push(Routes.HOME), 2000);
       },
       onError: (error) => {
         showAndSetToastMessage(
@@ -307,7 +312,7 @@ const AddGradePage: React.FC = () => {
           onDidDismiss={() => setShowToast(false)}
           message={toastMessage}
           duration={2000}
-          color="danger"
+          color={toastColor}
         />
       </IonContent>
 

--- a/src/pages/home/grades/GradeEntryPage.tsx
+++ b/src/pages/home/grades/GradeEntryPage.tsx
@@ -60,7 +60,8 @@ const GradeEntryPage: React.FC = () => {
   );
 
   const [editingId, setEditingId] = useState<string | null>(null);
-  const { showToast, toastMessage, setShowToast, showMessage } = useToast();
+  const { showToast, toastMessage, toastColor, setShowToast, showMessage } =
+    useToast();
 
   const gradeForm = useForm({
     defaultValues: {
@@ -99,7 +100,7 @@ const GradeEntryPage: React.FC = () => {
   const handleDelete = (gradeId: string) => {
     deleteGradeMutation.mutate(gradeId, {
       onSuccess: () => {
-        showMessage('Note erfolgreich gelöscht.');
+        showMessage('Note erfolgreich gelöscht.', 'success');
       },
       onError: (error) => {
         showMessage(
@@ -143,7 +144,7 @@ const GradeEntryPage: React.FC = () => {
       },
       {
         onSuccess: () => {
-          showMessage('Note erfolgreich aktualisiert.');
+          showMessage('Note erfolgreich aktualisiert.', 'success');
           setEditingId(null);
         },
         onError: (error) => {
@@ -288,7 +289,7 @@ const GradeEntryPage: React.FC = () => {
             onDidDismiss={() => setShowToast(false)}
             message={toastMessage}
             duration={2000}
-            color="danger"
+            color={toastColor}
           />
         </Layout>
       </IonContent>


### PR DESCRIPTION
## Summary

  - Updated useToast hook to support color parameter for dynamic toast colors
  - Fixed AddGradePage to show success message in green before navigation
  - Fixed GradeEntryPage to show success/delete messages in green
  - Changed toast timing to display message before navigation to home

## Testing

Tested locally using

- [x] `npm run dev`
- [ ] `ionic capacitor run android`
- [ ] `ionic capacitor run ios`

## Issue

- Closes [#149]
