### PR TITLE
fix: profile-icon is also now visible in light mode

### DIFF
--- a/src/pages/home/HomePage.css
+++ b/src/pages/home/HomePage.css
@@ -125,7 +125,7 @@
 
 @media (prefers-color-scheme: light) {
   .profile-settings-button {
-    background: #746f6f; 
+    background: #746f6f;
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- Provide a brief description of the changes. -->

## Testing

Tested locally using

- [ ] `npm run dev`
- [ ] `ionic capacitor run android`
- [ ] `ionic capacitor run ios`

## Issue

- Closes [ISSUER_NUMBER]
