### PR TITLE
chore: update dependabot configuration to include react-router patterns in Ionic group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,18 +22,15 @@ updates:
         patterns:
           - '@types/react*'
 
-      react-router:
-        patterns:
-          - 'react-router*'
-          - '@types/react-router*'
-
       # =====================
-      # Ionic
+      # Ionic + React Router
       # =====================
-      ionic-core:
+      ionic-and-routing:
         patterns:
           - '@ionic/*'
           - 'ionicons'
+          - 'react-router*'
+          - '@types/react-router*'
 
       ionic-native:
         patterns:


### PR DESCRIPTION
…ns in Ionic group

## Summary

<!-- Provide a brief description of the changes. -->

## Testing

Tested locally using

- [ ] `npm run dev`
- [ ] `ionic capacitor run android`
- [ ] `ionic capacitor run ios`

## Issue

- Closes [ISSUER_NUMBER]
