### PR TITLE
feat: reset success and toast states on view enter in add exam and grade forms

### DIFF
--- a/src/features/add-exam/add-exam-form.tsx
+++ b/src/features/add-exam/add-exam-form.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IonContent, IonToast } from '@ionic/react';
+import { IonContent, IonToast, useIonViewWillEnter } from '@ionic/react';
 import { format } from 'date-fns';
 import { useAddExam, useSchools, useSchoolSubjects } from '@/hooks';
 import { useAppForm } from '@/shared/components/form';
@@ -31,6 +31,11 @@ const AddExamForm: React.FC<AddExamFormProps> = ({ onSuccess }) => {
     useSchoolSubjects(selectedSchoolId);
 
   const addExamMutation = useAddExam();
+
+  useIonViewWillEnter(() => {
+    setShowSuccess(false);
+    setShowToast(false);
+  });
 
   const form = useAppForm({
     defaultValues: {

--- a/src/features/add-grade/add-grade-form.tsx
+++ b/src/features/add-grade/add-grade-form.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { IonContent, IonToast } from '@ionic/react';
+import { IonContent, IonToast, useIonViewWillEnter } from '@ionic/react';
 import { format, parseISO } from 'date-fns';
 import {
   useAddGradeWithExam,
@@ -36,6 +36,11 @@ const AddGradeForm: React.FC<AddGradeFormProps> = ({ onSuccess }) => {
     useSchoolSubjects(selectedSchoolId);
 
   const addGradeWithExamMutation = useAddGradeWithExam();
+
+  useIonViewWillEnter(() => {
+    setShowSuccess(false);
+    setShowToast(false);
+  });
 
   const form = useAppForm({
     defaultValues: {


### PR DESCRIPTION
…ade forms

## Summary

<!-- Provide a brief description of the changes. -->

## Testing

Tested locally using

- [ ] `npm run dev`
- [ ] `ionic capacitor run android`
- [ ] `ionic capacitor run ios`

## Issue

- Closes [ISSUER_NUMBER]
