### PR TITLE
fix: ensure foreign key constraints are only enabled for non-native database connections

### DIFF
--- a/src/db/data-source.ts
+++ b/src/db/data-source.ts
@@ -126,19 +126,23 @@ export const initializeDatabase = async (): Promise<DataSource> => {
     AppDataSource = new DataSource(options);
     await AppDataSource.initialize();
 
-    const driver = AppDataSource.driver as SqljsDriver;
-    driver.databaseConnection.run('PRAGMA foreign_keys = ON;');
-
-    const originalAutoSave = driver.autoSave.bind(driver);
-    driver.autoSave = async () => {
-      await originalAutoSave();
+    if (!isNative) {
+      const driver = AppDataSource.driver as SqljsDriver;
       driver.databaseConnection.run('PRAGMA foreign_keys = ON;');
-    };
 
-    const [{ foreign_keys }] = await AppDataSource.query('PRAGMA foreign_keys');
-    console.log(
-      `PRAGMA foreign_keys = ${foreign_keys} (${foreign_keys === 1 ? 'ON' : 'OFF'}) [${isNative ? 'native' : 'web'}]`,
-    );
+      const originalAutoSave = driver.autoSave.bind(driver);
+      driver.autoSave = async () => {
+        await originalAutoSave();
+        driver.databaseConnection.run('PRAGMA foreign_keys = ON;');
+      };
+
+      const [{ foreign_keys }] = await AppDataSource.query(
+        'PRAGMA foreign_keys',
+      );
+      console.log(
+        `PRAGMA foreign_keys = ${foreign_keys} (${foreign_keys === 1 ? 'ON' : 'OFF'}) [web]`,
+      );
+    }
 
     console.log('Data Source has been initialized successfully.');
 

--- a/src/db/migrations/1771848100000-add-fk-semester-school.ts
+++ b/src/db/migrations/1771848100000-add-fk-semester-school.ts
@@ -18,6 +18,8 @@ export class AddFkSemesterSchool1771848100000 {
         CONSTRAINT "FK_semester_school" FOREIGN KEY ("schoolId") REFERENCES "school" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
       )
     `);
+
+    await queryRunner.query(`DELETE FROM "semester" WHERE "schoolId" IS NULL`);
     await queryRunner.query(`
       INSERT INTO "temporary_semester" ("id", "createdAt", "updatedAt", "version", "appInstanceId", "name", "startDate", "endDate", "schoolId")
       SELECT "id", "createdAt", "updatedAt", "version", "appInstanceId", "name", "startDate", "endDate", "schoolId"


### PR DESCRIPTION
…se connections

## Summary

<!-- Provide a brief description of the changes. -->

## Testing

Tested locally using

- [x] `npm run dev`
- [ ] `ionic capacitor run android`
- [x] `ionic capacitor run ios`

## Issue

- Closes #554 
