### PR TITLE
fix: lower pbxproj objectVersion to 56 for CocoaPods compatibility

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */


### PR DESCRIPTION
## Summary

<!-- Provide a brief description of the changes. -->

## Testing

Tested locally using

- [ ] `npm run dev`
- [ ] `ionic capacitor run android`
- [ ] `ionic capacitor run ios`

## Issue

- Closes #674 
