### PR TITLE
feat: add all-exams overview grouped by month, linked from home

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -6,6 +6,7 @@ import CalendarPage from '@/pages/home/calendar/CalendarPage';
 import SettingsPage from '@/pages/home/settings/SettingsPage';
 import AddExamPage from '@/pages/home/exams/AddExamPage';
 import ScanExamPage from '@/pages/home/exams/ScanExamPage';
+import AllExamsPage from '@/pages/home/exams/AllExamsPage';
 import OnboardingPage from '@/pages/onboarding/OnboardingPage';
 import SchoolPage from '@/pages/home/school/SchoolPage';
 import AddGradePage from '@/pages/home/grades/AddGradePage';
@@ -38,6 +39,7 @@ export function AppRouter() {
         <Route exact path={Routes.SETTINGS} component={SettingsPage} />
         <Route exact path={Routes.EXAMS_ADD} component={AddExamPage} />
         <Route exact path={Routes.EXAMS_SCAN} component={ScanExamPage} />
+        <Route exact path={Routes.EXAMS_ALL} component={AllExamsPage} />
         <Route exact path={Routes.EXAM_EDIT} component={EditExamPage} />
       </Switch>
 

--- a/src/hooks/queries/useExamQueries.ts
+++ b/src/hooks/queries/useExamQueries.ts
@@ -38,6 +38,13 @@ export const useUpcomingExams = () => {
   return useQuery(UpcomingExamsQuery);
 };
 
+export const useAllExams = () => {
+  return useQuery({
+    queryKey: examKeys.lists(),
+    queryFn: () => ExamService.fetchAll(),
+  });
+};
+
 export const createExamDetailQuery = (examId: string) => ({
   queryKey: examKeys.detail(examId),
   queryFn: () => ExamService.findById(examId),

--- a/src/pages/home/exams/AllExamsPage.tsx
+++ b/src/pages/home/exams/AllExamsPage.tsx
@@ -1,0 +1,94 @@
+import React, { useMemo, useState } from 'react';
+import { IonContent, IonIcon, IonPage, useIonRouter } from '@ionic/react';
+import { chevronBack, chevronForward, bookOutline } from 'ionicons/icons';
+import Header from '@/components/Header/Header';
+import { useAllExams } from '@/hooks/queries';
+import { Routes } from '@/routes';
+import type { Exam } from '@/db/entities';
+import '../school/SchoolPage.css';
+import '../main/MainPage.css';
+
+const AllExamsPage: React.FC = () => {
+  const router = useIonRouter();
+  const { data: exams = [] } = useAllExams();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // Group all exams (past and future) by "month year", newest first.
+  const groups = useMemo(() => {
+    const map = new Map<string, { label: string; exams: Exam[] }>();
+    for (const exam of exams) {
+      const date = new Date(exam.date);
+      const key = `${date.getFullYear()}-${date.getMonth()}`;
+      const label = date.toLocaleDateString('de-CH', {
+        month: 'long',
+        year: 'numeric',
+      });
+      const group = map.get(key) ?? { label, exams: [] };
+      group.exams.push(exam);
+      map.set(key, group);
+    }
+    return Array.from(map.values());
+  }, [exams]);
+
+  const activeGroup = groups[activeIndex];
+
+  const openExam = (examId: string) =>
+    router.push(Routes.EXAM_EDIT.replace(':examId', examId));
+
+  return (
+    <IonPage className="home-page">
+      <Header title="Alle Prüfungen" backButton defaultHref={Routes.HOME} />
+      <IonContent className="home-content">
+        <div className="school-semester-selector">
+          <button
+            className="school-semester-arrow"
+            onClick={() => setActiveIndex((i) => i - 1)}
+            disabled={activeIndex <= 0}
+          >
+            <IonIcon icon={chevronBack} />
+          </button>
+          <span className="school-semester-name">
+            {activeGroup?.label ?? '—'}
+          </span>
+          <button
+            className="school-semester-arrow"
+            onClick={() => setActiveIndex((i) => i + 1)}
+            disabled={activeIndex >= groups.length - 1}
+          >
+            <IonIcon icon={chevronForward} />
+          </button>
+        </div>
+
+        <div className="subjects-container">
+          {activeGroup ? (
+            activeGroup.exams.map((exam) => (
+              <div key={exam.id} className="subject-item-container">
+                <div className="subject-item" onClick={() => openExam(exam.id)}>
+                  <div className="subject-icon-badge">
+                    <IonIcon icon={bookOutline} className="subject-initial" />
+                  </div>
+                  <div className="subject-info">
+                    <h3 className="subject-name">{exam.name}</h3>
+                    <div className="subject-average-text">
+                      {new Date(exam.date).toLocaleDateString('de-CH')}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="subjects-empty-state">
+              <div className="subjects-empty-icon">
+                <IonIcon icon={bookOutline} />
+              </div>
+              <h3>Keine Prüfungen</h3>
+              <p>Es sind noch keine Prüfungen vorhanden.</p>
+            </div>
+          )}
+        </div>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default AllExamsPage;

--- a/src/pages/home/main/MainPage.css
+++ b/src/pages/home/main/MainPage.css
@@ -161,6 +161,18 @@
   letter-spacing: -0.3px;
 }
 
+.section-title-link {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.section-title-arrow {
+  font-size: 16px;
+  color: var(--ion-color-medium);
+}
+
 .header-action-button {
   width: 28px;
   height: 28px;

--- a/src/pages/home/main/MainPage.tsx
+++ b/src/pages/home/main/MainPage.tsx
@@ -7,7 +7,7 @@ import {
   IonRefresherContent,
   useIonRouter,
 } from '@ionic/react';
-import { add, personCircleOutline } from 'ionicons/icons';
+import { add, chevronForward, personCircleOutline } from 'ionicons/icons';
 import { useAddSchool, useUserName } from '@/hooks/queries';
 import { Routes } from '@/routes';
 import NavigationModal from '@/components/navigation/home/NavigationModal';
@@ -99,7 +99,16 @@ function MainPage() {
 
           <div className="main-section">
             <div className="section-header">
-              <h2 className="section-title">Prüfungen</h2>
+              <div
+                className="section-title-link"
+                onClick={() => router.push(Routes.EXAMS_ALL, 'forward')}
+              >
+                <h2 className="section-title">Prüfungen</h2>
+                <IonIcon
+                  icon={chevronForward}
+                  className="section-title-arrow"
+                />
+              </div>
               <div
                 className="header-action-button"
                 onClick={() => router.push(Routes.EXAMS_ADD, 'forward')}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -27,5 +27,6 @@ export enum Routes {
   // Exams routes
   EXAMS_ADD = '/main/home/exams/add',
   EXAMS_SCAN = '/main/home/exams/scan',
+  EXAMS_ALL = '/main/home/exams/all',
   EXAM_EDIT = '/main/home/exams/:examId/edit',
 }


### PR DESCRIPTION
## Summary

<!-- Provide a brief description of the changes. -->

## Testing

Tested locally using

- [ ] `npm run dev`
- [ ] `ionic capacitor run android`
- [ ] `ionic capacitor run ios`

## Issue

- Closes #667 
