### PR TITLE
fix: save 0% weight correctly on exam scan

### DIFF
--- a/src/features/scan-exam/scan-exam-form.tsx
+++ b/src/features/scan-exam/scan-exam-form.tsx
@@ -71,7 +71,9 @@ const ScanExamForm: React.FC = () => {
           examName: value.examName.trim(),
           date: new Date(value.date + 'T12:00:00'),
           score: value.score,
-          weight: percentageToDecimal(Number(value.weight) || 100),
+          weight: percentageToDecimal(
+            Number.isFinite(Number(value.weight)) ? Number(value.weight) : 100,
+          ),
         });
 
         if (photoPaths.length > 0 && grade.exam?.id) {


### PR DESCRIPTION
## Summary

<!-- Provide a brief description of the changes. -->

## Testing

Tested locally using

- [x] `npm run dev`
- [ ] `ionic capacitor run android`
- [x] `ionic capacitor run ios`

## Issue

- Closes #693 
