### PR TITLE
docs: point Codecov badge at nca-apprentices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NetGrade
 
-[![Coverage Status](https://codecov.io/gh/kevin-nca/netgrade/branch/main/graph/badge.svg)](https://codecov.io/gh/kevin-nca/netgrade)
+[![Coverage Status](https://codecov.io/gh/nca-apprentices/netgrade/branch/main/graph/badge.svg)](https://codecov.io/gh/nca-apprentices/netgrade)
 
 ## Overview
 


### PR DESCRIPTION
The repository moved from `kevin-nca` to the `nca-apprentices` organization. The Codecov badge image and its link still pointed at the old owner, so the badge no longer resolves.

Note: the badge will stay broken until the project is re-linked in Codecov under the new owner — this change only fixes the URL.